### PR TITLE
write dn to the right port when one is specified in the invocation of (write)

### DIFF
--- a/ldif-core-impl.scm
+++ b/ldif-core-impl.scm
@@ -281,7 +281,7 @@
  (define (write ldif #!optional (port (current-output-port)))
    (assert (ldif? ldif))
    (display "dn: " port)
-   (rfc4514-write (ldif-dn ldif))
+   (rfc4514-write (ldif-dn ldif) port)
    (newline port)
    (ldif-attributes-fold ldif-write-a+v port (ldif-attributes ldif))
    (newline port)


### PR DESCRIPTION

This fixes a typo resulting in (write ldif port) writing to port
anything but the dn, which is always written to (current-output-port).